### PR TITLE
fix(issues): set default sorting to LAST_SEEN

### DIFF
--- a/pkg/api/escape/issues.go
+++ b/pkg/api/escape/issues.go
@@ -53,6 +53,8 @@ func ListIssues(ctx context.Context, next string, filters *ListIssuesFilters) ([
 		req = req.Cursor(next)
 	}
 
+	req = req.SortType("LAST_SEEN")
+
 	if filters != nil {
 		if len(filters.Status) > 0 {
 			req = req.Status(strings.Join(filters.Status, ","))


### PR DESCRIPTION
This PR updates the default sorting when fetching issues to LAST_SEEN to make it deterministic of which order the issues will be received.