### PR TITLE
chore: bump go to latest 1.26.2

### DIFF
--- a/.github/workflows/cli-tests.yaml
+++ b/.github/workflows/cli-tests.yaml
@@ -7,7 +7,7 @@ on:
   workflow_dispatch:
 
 env:
-  GO_VERSION: "1.25.8"
+  GO_VERSION: "1.26.2"
 
 jobs:
   go-fmt:
@@ -97,10 +97,10 @@ jobs:
           - ubuntu-24.04-arm
           - macos-latest
         golang:
-          - "1.23"
           - "1.24"
           - "1.25"
-          - "1.25.8"
+          - "1.26"
+          - "1.26.2"
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v6

--- a/.github/workflows/e2e-tests.yaml
+++ b/.github/workflows/e2e-tests.yaml
@@ -7,7 +7,7 @@ on:
   workflow_dispatch:
 
 env:
-  GO_VERSION: "1.23.0"
+  GO_VERSION: "1.26.2"
 
 jobs:
   e2e:

--- a/.github/workflows/github-action-tests.yaml
+++ b/.github/workflows/github-action-tests.yaml
@@ -8,7 +8,7 @@ on:
   workflow_dispatch:
 
 env:
-  GO_VERSION: "1.25.0"
+  GO_VERSION: "1.26.2"
   CLI_IMAGE: escape-cli:pr-${{ github.sha }}
 
 jobs:

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/Escape-Technologies/cli
 
-go 1.25.8
+go 1.26.2
 
 require (
 	github.com/Escape-Technologies/go-socks5 v1.0.0


### PR DESCRIPTION
This MR bumps golang to its latest version, 1.26.2, to mitigate CVEs in the current version (1.25.8).