### PR TITLE
feat(banner): hide banner when generating shell completion

### DIFF
--- a/pkg/cli/cmd/root.go
+++ b/pkg/cli/cmd/root.go
@@ -75,7 +75,9 @@ DOCUMENTATION:
 			return fmt.Errorf("failed to set output format: %w", err)
 		}
 		out.SetInputSchema(rootCmdInputSchema)
-		printStartupHeader(cmd.Context())
+		if !isCompletionCommand(cmd) {
+			printStartupHeader(cmd.Context())
+		}
 		return nil
 	},
 	RunE: func(cmd *cobra.Command, _ []string) error {
@@ -194,6 +196,15 @@ func resolveUpgrade(ctx context.Context) string {
 	case <-checkCtx.Done():
 		return ""
 	}
+}
+
+func isCompletionCommand(cmd *cobra.Command) bool {
+	for c := cmd; c != nil; c = c.Parent() {
+		if c.Name() == "completion" {
+			return true
+		}
+	}
+	return false
 }
 
 func isPrettyOutput() bool {


### PR DESCRIPTION
## Summary
- Suppress the Escape CLI startup logo/header when running `escape-cli completion {zsh,bash,fish,powershell}`, so shells sourcing the completion script (e.g. via `source <(escape-cli completion zsh)` in `.zshrc`) don't see the banner on every new shell.
- Added an `isCompletionCommand` helper that walks the command ancestry and is checked in the root `PersistentPreRunE` before printing the header.

## Test plan
- [x] `escape-cli completion zsh` → stderr is empty, stdout is the completion script
- [x] Other commands (e.g. `escape-cli version`, `escape-cli --help`) still print the banner
- [ ] Sanity-check sourcing the completion script in a fresh shell

🤖 Generated with [Claude Code](https://claude.com/claude-code)